### PR TITLE
Fix version for initial PR if not tag exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ configuration driven.
 Inside your GHA pipeline, simply add the following step:
 
 ```yaml
-    - uses: DragosDumitrache/versioner/versioner@v2.5.1
+    - uses: DragosDumitrache/versioner/versioner@v2.6.1
 ```
 
 Incrementing the `major` or `minor` versions is done simply through a bump in your project's

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "default_branch": "master",
   "major": "2",
-  "minor": "5"
+  "minor": "6"
 }

--- a/version.sh
+++ b/version.sh
@@ -94,6 +94,9 @@ function semver {
     next_patch=$(($commits + $patch))
     next_version="${major_minor}.${next_patch}"
   else
+    commits=$(git rev-list --all --count)
+    # shellcheck disable=SC2004
+    next_patch=$commits
     next_version="${next_major}.${next_minor}.${next_patch}"
   fi
 


### PR DESCRIPTION
Previously, if no tag existed, the patch version was considered to be `0`, for all commits on a branch. This changes will include all commits so far, so that we still get a unique version number of each commit on a PR, in the event that no tag has been published so far