### PR TITLE
Remove mention of include_tag_prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,7 @@ A bash script that calculates semantic versions from git tags and branches, with
      "default_branch": "main",
      "major": "1",
      "minor": "0",
-     "tag_prefix": "v",
-     "include_v_prefix": true
+     "tag_prefix": "v"
    }
    ```
 
@@ -70,8 +69,7 @@ The `version.json` file supports the following options:
 | `default_branch` | Main branch name | `"master"` | `"main"`, `"master"` |
 | `major` | Minimum major version | `"0"` | `"1"`, `"2"` |
 | `minor` | Minimum minor version | `"0"` | `"0"`, `"5"` |
-| `tag_prefix` | Prefix for git tags | `""` | `"v"`, `"release-"` |
-| `include_v_prefix` | Include v in output | `false` | `true`, `false` |
+| `tag_prefix` | Prefix for tags and output | `""` | `"v"`, `"release-"` |
 
 ### Version Behavior
 
@@ -165,14 +163,13 @@ git commit -m "Improve API"
   "default_branch": "main",
   "major": "0",
   "minor": "1", 
-  "tag_prefix": "",
-  "include_v_prefix": false
+  "tag_prefix": ""
 }
 ```
 
 ```bash
 ./version.sh
-# Output: 0.1.0 (no "v" prefix)
+# Output: 0.1.0 (no prefix)
 ```
 
 ### Integration Examples
@@ -266,26 +263,23 @@ The script automatically normalizes branch names:
 
 #### Tag Prefix Examples
 ```json
-// Docker-style tags
+// With v prefix
 {
-  "tag_prefix": "v",
-  "include_v_prefix": true
+  "tag_prefix": "v"
 }
 // Result: v1.2.3
 
 // No prefix
 {
-  "tag_prefix": "", 
-  "include_v_prefix": false
+  "tag_prefix": ""
 }
 // Result: 1.2.3
 
 // Custom prefix
 {
-  "tag_prefix": "release-",
-  "include_v_prefix": false  
+  "tag_prefix": "release-"
 }
-// Result: 1.2.3 (but looks for release-1.2.2 tags)
+// Result: release-1.2.3
 ```
 
 #### Version Constraints

--- a/version.json
+++ b/version.json
@@ -1,7 +1,6 @@
 {
   "default_branch": "master",
   "major": "3",
-  "minor": "0",
-  "tag_prefix": "",
-  "include_v_prefix": false
+  "minor": "1",
+  "tag_prefix": ""
 }

--- a/version.sh
+++ b/version.sh
@@ -10,8 +10,7 @@ function _initialise_version() {
   "default_branch": "master",
   "major": "0",
   "minor": "0",
-  "tag_prefix": "",
-  "include_v_prefix": false
+  "tag_prefix": ""
 }
 EOF
   fi
@@ -189,13 +188,12 @@ function semver() {
   _initialise_version
 
   # Read configuration
-  local default_branch next_major next_minor tag_prefix include_v_prefix
+  local default_branch next_major next_minor tag_prefix
 
   default_branch=$(jq -r '.default_branch // "master"' version.json)
   next_major=$(jq -r '.major // "0"' version.json)
   next_minor=$(jq -r '.minor // "0"' version.json)
   tag_prefix=$(jq -r '.tag_prefix // ""' version.json)
-  include_v_prefix=$(jq -r '.include_v_prefix // false' version.json)
 
   # Get current branch and SHA
   local git_branch short_sha
@@ -225,9 +223,9 @@ function semver() {
     fi
   fi
 
-  # Add v prefix if configured
-  if [[ "$include_v_prefix" == "true" ]]; then
-    final_version="v${final_version}"
+  # Add tag prefix if configured
+  if [[ -n "$tag_prefix" ]]; then
+    final_version="${tag_prefix}${final_version}"
   fi
 
   echo "$final_version"


### PR DESCRIPTION
By default, if the prefix is specified, it will be included